### PR TITLE
Fix OpenAI model definitions by restricting to `gpt-4o` models for multimodal support

### DIFF
--- a/includes/OpenAI/OpenAI_AI_Service.php
+++ b/includes/OpenAI/OpenAI_AI_Service.php
@@ -142,7 +142,7 @@ class OpenAI_AI_Service implements Generative_AI_Service {
 					&& ! str_contains( $model_slug, '-instruct' )
 					&& ! str_contains( $model_slug, '-realtime' )
 					&& ! str_contains( $model_slug, '-audio' )
-                ) {
+				) {
 					if ( str_starts_with( $model_slug, 'gpt-4o' ) ) {
 						$model_caps[ $model_slug ] = $gpt_multimodal_capabilities;
 					} else {

--- a/includes/OpenAI/OpenAI_AI_Service.php
+++ b/includes/OpenAI/OpenAI_AI_Service.php
@@ -137,8 +137,12 @@ class OpenAI_AI_Service implements Generative_AI_Service {
 		return array_reduce(
 			$model_slugs,
 			static function ( array $model_caps, string $model_slug ) use ( $gpt_capabilities, $gpt_multimodal_capabilities ) {
-				if ( str_starts_with( $model_slug, 'gpt-' ) && ! str_contains( $model_slug, '-instruct' ) ) {
-					if ( str_starts_with( $model_slug, 'gpt-4' ) ) {
+				if ( str_starts_with( $model_slug, 'gpt-' )
+                     && ! str_contains( $model_slug, '-instruct' )
+				     && ! str_contains( $model_slug, '-realtime' )
+				     && ! str_contains( $model_slug, '-audio' )
+                ) {
+					if ( str_starts_with( $model_slug, 'gpt-4o' ) ) {
 						$model_caps[ $model_slug ] = $gpt_multimodal_capabilities;
 					} else {
 						$model_caps[ $model_slug ] = $gpt_capabilities;

--- a/includes/OpenAI/OpenAI_AI_Service.php
+++ b/includes/OpenAI/OpenAI_AI_Service.php
@@ -137,10 +137,11 @@ class OpenAI_AI_Service implements Generative_AI_Service {
 		return array_reduce(
 			$model_slugs,
 			static function ( array $model_caps, string $model_slug ) use ( $gpt_capabilities, $gpt_multimodal_capabilities ) {
-				if ( str_starts_with( $model_slug, 'gpt-' )
-                     && ! str_contains( $model_slug, '-instruct' )
-				     && ! str_contains( $model_slug, '-realtime' )
-				     && ! str_contains( $model_slug, '-audio' )
+				if (
+					str_starts_with( $model_slug, 'gpt-' )
+					&& ! str_contains( $model_slug, '-instruct' )
+					&& ! str_contains( $model_slug, '-realtime' )
+					&& ! str_contains( $model_slug, '-audio' )
                 ) {
 					if ( str_starts_with( $model_slug, 'gpt-4o' ) ) {
 						$model_caps[ $model_slug ] = $gpt_multimodal_capabilities;


### PR DESCRIPTION
I encountered an issue with the current model selection for the OpenAI service. It defaults to gpt-4-turbo-preview as the preferred multimodal model, but this model fails to generate image alt text, returning the error:

	“Invalid content type. image_url is only supported by certain models.”

This error persists even though a valid base64-encoded image is sent in the request.

To resolve this, I’ve updated the model selection to use only gpt-4o models, which are compatible and successfully handle the image input for generating alt text.

I also excluded realtime and audio models. Realtime models are incompatiable with the `v1/chat/completions` endpoint (they require `v1/completions` endpoint).  Audio models don't accept image inputs.

Let me know if this fits or if you need any more tweaks!