### PR TITLE
Remove prefix from base64 inline image data for Anthropic AI integration

### DIFF
--- a/includes/Anthropic/Anthropic_AI_Model.php
+++ b/includes/Anthropic/Anthropic_AI_Model.php
@@ -430,8 +430,13 @@ class Anthropic_AI_Model implements Generative_AI_Model, With_Multimodal_Input, 
 							'source' => array(
 								'type'       => 'base64',
 								'media_type' => $mime_type,
-								'data'       => $part->get_base64_data(),
-							),
+								// The Anthropic AI API expects inlineData blobs to be without the prefix.
+								'data'     => preg_replace(
+									'/^data:[a-z]+\/[a-z]+;base64,/',
+									'',
+									$part->get_base64_data()
+								),
+							)
 						);
 					} else {
 						throw new InvalidArgumentException(

--- a/includes/Anthropic/Anthropic_AI_Model.php
+++ b/includes/Anthropic/Anthropic_AI_Model.php
@@ -431,12 +431,12 @@ class Anthropic_AI_Model implements Generative_AI_Model, With_Multimodal_Input, 
 								'type'       => 'base64',
 								'media_type' => $mime_type,
 								// The Anthropic AI API expects inlineData blobs to be without the prefix.
-								'data'     => preg_replace(
+								'data'       => preg_replace(
 									'/^data:[a-z]+\/[a-z]+;base64,/',
 									'',
 									$part->get_base64_data()
 								),
-							)
+							),
 						);
 					} else {
 						throw new InvalidArgumentException(


### PR DESCRIPTION
Anthropic AI has the same requirements as the Google API. This patch is identical to https://github.com/felixarntz/ai-services/blob/main/includes/Google/Google_AI_Model.php#L439-L443

This resolves this error:

`Error generating alt text: Error: Generating content with model claude-3-sonnet-20240229 failed: Error while making request to the Anthropic API:
messages.0.content.1.image.source.base64: invalid base64 data` 