### PR TITLE
Pass service slug to ai_services_model_params filter

### DIFF
--- a/docs/Customizing-AI-Services-Model-Parameters.md
+++ b/docs/Customizing-AI-Services-Model-Parameters.md
@@ -13,14 +13,16 @@ Here is an example code snippet which injects a custom system instruction whenev
 ```php
 add_filter(
 	'ai_services_model_params',
-	function ( $params ) {
-		if ( 'my-movie-expert' === $params['feature'] ) {
+	function ( $params, $service ) {
+		if ( 'my-movie-expert' === $params['feature'] && 'google' === $service ) {
 			$params['systemInstruction']  = 'You are a movie expert. You can answer questions about movies, actors, directors, and movie references.';
 			$params['systemInstruction'] .= ' If the user asks you about anything unrelated to movies, you should politely deny the request.';
 			$params['systemInstruction'] .= ' You may use famous movie quotes in your responses to make the conversation more engaging.';
 		}
 		return $params;
-	}
+	},
+	10,
+	2
 );
 ```
 

--- a/includes/Services/Decorators/AI_Service_Decorator.php
+++ b/includes/Services/Decorators/AI_Service_Decorator.php
@@ -146,9 +146,11 @@ class AI_Service_Decorator implements Generative_AI_Service {
 		 * @param array<string, mixed> $model_params The model parameters. Commonly supports at least the parameters
 		 *                                           'feature', 'capabilities', 'generationConfig' and
 		 *                                           'systemInstruction'.
+		 * @param string               $service_slug The service slug.
+		 *
 		 * @return array<string, mixed> The processed model parameters.
 		 */
-		$filtered_model_params = (array) apply_filters( 'ai_services_model_params', $model_params );
+		$filtered_model_params = (array) apply_filters( 'ai_services_model_params', $model_params, $this->service->get_service_slug() );
 
 		// Ensure that the feature identifier cannot be changed.
 		$filtered_model_params['feature'] = $model_params['feature'];


### PR DESCRIPTION
This adds the AI service slug as a parameter to the `ai_services_model_params` filter. By including this parameter, developers can now customize the system instruction for a specific AI service, enabling greater flexibility and control over how the filter is applied.