### PR TITLE
Generate build provenance attestation

### DIFF
--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -10,6 +10,10 @@ jobs:
     release:
         name: New Release${{ github.event_name == 'workflow_dispatch' && ' (dry run)' || '' }}
         runs-on: ubuntu-latest
+        permissions:
+          attestations: write
+          contents: read
+          id-token: write
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -70,3 +74,9 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   files: ${{ steps.wporg-deployment.outputs.zip-path }}
+
+            - name: Generate build provenance attestation
+              uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+              with:
+                zip-path: ${{ steps.wporg-deployment.outputs.zip-path }}
+                dry-run: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -81,4 +81,5 @@ jobs:
               uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
               with:
                 zip-path: ${{ steps.wporg-deployment.outputs.zip-path }}
+                version: ${{ steps.get-version.outputs.version }}
                 dry-run: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -11,12 +11,12 @@ jobs:
         name: New Release${{ github.event_name == 'workflow_dispatch' && ' (dry run)' || '' }}
         runs-on: ubuntu-latest
         permissions:
-          attestations: write
-          contents: read
-          id-token: write
+            attestations: write
+            contents: read
+            id-token: write
         environment:
-          name: WordPress.org
-          url: "https://wordpress.org/plugins/${{ github.event.repository.name }}/"
+            name: WordPress.org
+            url: 'https://wordpress.org/plugins/${{ github.event.repository.name }}/'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -80,6 +80,6 @@ jobs:
             - name: Generate build provenance attestation
               uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
               with:
-                zip-path: ${{ steps.wporg-deployment.outputs.zip-path }}
-                version: ${{ steps.get-version.outputs.version }}
-                dry-run: ${{ github.event_name == 'workflow_dispatch' }}
+                  zip-path: ${{ steps.wporg-deployment.outputs.zip-path }}
+                  version: ${{ steps.get-version.outputs.version }}
+                  dry-run: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -28,7 +28,6 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version-file: '.nvmrc'
-                  cache: npm
 
             - name: Build plugin
               run: |

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -78,7 +78,7 @@ jobs:
                   files: ${{ steps.wporg-deployment.outputs.zip-path }}
 
             - name: Generate build provenance attestation
-              uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+              uses: johnbillion/action-wordpress-plugin-attestation@0.7.1
               with:
                   zip-path: ${{ steps.wporg-deployment.outputs.zip-path }}
                   version: ${{ steps.get-version.outputs.version }}

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -14,6 +14,9 @@ jobs:
           attestations: write
           contents: read
           id-token: write
+        environment:
+          name: WordPress.org
+          url: "https://wordpress.org/plugins/${{ github.event.repository.name }}/"
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
This implements three changes relating to deployment to the wordpress.org plugin directory:

1. Generates build provenance attestation using [my action for this](https://github.com/johnbillion/action-wordpress-plugin-attestation) which ties the zip file on wordpress.org back to the GitHub Actions workflow that performed the deployment.
2. Disables the use of caching during deployment to avoid the potential for cache poisoning being able to affect the deployed asset. [This helps facilitate SLSA at level 3](https://github.com/johnbillion/action-wordpress-plugin-attestation#what-slsa-level-does-this-facilitate).
3. Sets the environment name during deployment. This means the plugin's URL on wordpress.org shows up in various places on GitHub.

## Steps to test

This isn't testable in isolation because the workflow only runs when you publish a release, but [it's used by several other plugins](https://github.com/johnbillion/action-wordpress-plugin-attestation/network/dependents).