### PR TITLE
Fix license refs to `GPL-2.0-or-later`

### DIFF
--- a/ai-services.php
+++ b/ai-services.php
@@ -8,8 +8,8 @@
  * Version: 0.6.3
  * Author: Felix Arntz
  * Author URI: https://felix-arntz.me
- * License: GPLv2 or later
- * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * License: GPL-2.0-or-later
+ * License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain: ai-services
  *
  * @package ai-services

--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Author URI:   https://felix-arntz.me
 Contributors: flixos90
 Tested up to: 6.8
 Stable tag:   0.6.3
-License:      GPLv2 or later
-License URI:  https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+License:      GPL-2.0-or-later
+License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 Tags:         ai, text generation, image generation, function calling, multimodal
 
 Makes AI centrally available in WordPress, whether via PHP, REST API, JavaScript, or WP-CLI - for any provider.


### PR DESCRIPTION
This pull request updates the license information in the project files to use a more standardized SPDX identifier format of `GPL-2.0-or-later` and its explicit link to https://spdx.org/licenses/GPL-2.0-or-later.html to match what's defined in composer.json and package.json files. The changes ensure consistency and adherence to modern licensing practices.

License updates:

* [`ai-services.php`](diffhunk://#diff-63a89a4da3944d5320895f6dca883532f1091b5b8e5d790005cb1c07702370c6L11-R12): Updated the license from "GPLv2 or later" to "GPL-2.0-or-later" and replaced the license URI with the corresponding SPDX URI.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L10-R11): Made the same license updates as in `ai-services.php` for consistency across documentation.