### PR TITLE
Add WordPress Playground `blueprint.json` for plugin preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,24 @@
+{
+    "landingPage": "/wp-admin/admin.php?page=ais_playground",
+    "features": {
+      "networking": true
+    },
+    "steps": [
+      {
+        "step": "installPlugin",
+        "pluginData": {
+          "resource": "wordpress.org/plugins",
+          "slug": "ai-services"
+        },
+        "options": {
+          "activate": true
+        }
+      },
+      {
+        "step": "login",
+        "username": "admin",
+        "password": "password"
+      }
+    ]
+  }
+  

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,5 +1,5 @@
 {
-    "landingPage": "/wp-admin/admin.php?page=ais_playground",
+    "landingPage": "/wp-admin/options-general.php?page=ais_services",
     "features": {
       "networking": true
     },

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,24 +1,23 @@
 {
-    "landingPage": "/wp-admin/options-general.php?page=ais_services",
-    "features": {
-      "networking": true
-    },
-    "steps": [
-      {
-        "step": "installPlugin",
-        "pluginData": {
-          "resource": "wordpress.org/plugins",
-          "slug": "ai-services"
-        },
-        "options": {
-          "activate": true
-        }
-      },
-      {
-        "step": "login",
-        "username": "admin",
-        "password": "password"
-      }
-    ]
-  }
-  
+	"landingPage": "/wp-admin/options-general.php?page=ais_services",
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "ai-services"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		}
+	]
+}

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"landingPage": "/wp-admin/options-general.php?page=ais_services",
 	"features": {
 		"networking": true


### PR DESCRIPTION
This pull request is related to issue #41 and adds a `blueprint.json` file to enable the live preview button on the WordPress plugin repository. The blueprint is to install and activate the plugin, and then set the AI Playground as the landing page of the WordPress Playground. 

To test this blueprint, you can run with the blueprint runner or [access the url](https://playground.wordpress.net/builder/builder.html#{%22landingPage%22:%22/wp-admin/admin.php?page=ais_playground%22,%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22ai-services%22},%22options%22:{%22activate%22:true}},{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22}]})